### PR TITLE
Implemented ValueTask support

### DIFF
--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace TestHelper
 {
@@ -19,6 +20,7 @@ namespace TestHelper
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        private static readonly MetadataReference TaskExtensionsReference = MetadataReference.CreateFromFile(typeof(ValueTask<>).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";
@@ -152,7 +154,8 @@ namespace TestHelper
                 .AddMetadataReference(projectId, CorlibReference)
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, CSharpSymbolsReference)
-                .AddMetadataReference(projectId, CodeAnalysisReference);
+                .AddMetadataReference(projectId, CodeAnalysisReference)
+                .AddMetadataReference(projectId, TaskExtensionsReference);
 
             int count = 0;
             foreach (var source in sources)

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
@@ -34,6 +34,39 @@ namespace AsyncAwaitGames
         }
     }
 }";
+		
+        /// <summary>
+        /// File for testing diagnosis
+        /// </summary>
+        public const string TestDiagnosisValueTask = @"
+using System.Threading.Tasks;
+namespace AsyncAwaitGames
+{
+    // In my real case, that method just returns Task.
+    public interface ICallee { ValueTask<int> DoSomethingAsync(); }
+
+    public class Callee: ICallee
+    {
+        public async ValueTask<int> DoSomethingAsync() => await Task.FromResult(0); // Should not give a warning
+    }
+    public class Caller
+    {
+        public void DoCall()
+        {
+            ICallee xxx = new Callee();
+
+            // In my real case, the method just returns Task,
+            // so there is no type mismatch when assigning a result 
+            // either.
+            xxx.DoSomethingAsync(); // Should give a warning.
+
+            var task = xxx.DoSomethingAsync(); // Should not give a warning
+            xxx.DoSomethingAsync().Result; // Should not give a warning
+
+            xxx.DoSomethingAsync().ConfigureAwait(false); // Should give a warning
+        }
+    }
+}";
 
 		/// <summary>
 		/// Input that should be fixed

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -10,62 +10,83 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Lindhart.Analyser.MissingAwaitWarning
 {
-	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class LindhartAnalyserMissingAwaitWarningAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "LindhartAnalyserMissingAwaitWarning";
 
-		// You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
-		// See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
-		private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-		private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-		private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-		private const string Category = "UnintentionalUsage";
+        // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = "UnintentionalUsage";
 
-		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        private static readonly Type[] AwaitableTypes = new[]
+        {
+            typeof(Task),
+            typeof(Task<>),
+            typeof(ConfiguredTaskAwaitable),
+            typeof(ConfiguredTaskAwaitable<>),
+            typeof(ValueTask),
+            typeof(ValueTask<>),
+            typeof(ConfiguredValueTaskAwaitable),
+            typeof(ConfiguredValueTaskAwaitable<>)
+        };
 
-		public override void Initialize(AnalysisContext context)
-		{
-			context.RegisterSyntaxNodeAction(AnalyseSymbolNode, SyntaxKind.InvocationExpression);
-		}
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-		private void AnalyseSymbolNode(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
-		{
-			if (syntaxNodeAnalysisContext.Node is InvocationExpressionSyntax node)
-			{
-				if (syntaxNodeAnalysisContext
-						.SemanticModel
-						.GetSymbolInfo(node.Expression, syntaxNodeAnalysisContext.CancellationToken)
-						.Symbol is IMethodSymbol methodSymbol)
-				{
-					if (node.Parent is ExpressionStatementSyntax)
-					{
-						// Only checks for the two most common awaitable types. In principle this should instead check all types that are awaitable
-						if (EqualsType(methodSymbol.ReturnType, typeof(Task), typeof(ConfiguredTaskAwaitable)))
-						{
-							var diagnostic = Diagnostic.Create(Rule, node.GetLocation(), methodSymbol.ToDisplayString());
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyseSymbolNode, SyntaxKind.InvocationExpression);
+        }
 
-							syntaxNodeAnalysisContext.ReportDiagnostic(diagnostic);
-						}
-					}
-				}
-			}
-		}
+        private void AnalyseSymbolNode(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (syntaxNodeAnalysisContext.Node is InvocationExpressionSyntax node)
+            {
+                var symbolInfo = syntaxNodeAnalysisContext
+                    .SemanticModel
+                    .GetSymbolInfo(node.Expression, syntaxNodeAnalysisContext.CancellationToken);
+                
+                if ((symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault())
+                    is IMethodSymbol methodSymbol)
+                {
+                    if (node.Parent is ExpressionStatementSyntax)
+                    {
+                        // Only checks for the two most common awaitable types. In principle this should instead check all types that are awaitable
+                        if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes))
+                        {
+                            var diagnostic = Diagnostic.Create(Rule, node.GetLocation(), methodSymbol.ToDisplayString());
 
-		/// <summary>
-		/// Checks if the <paramref name="typeSymbol"/> is one of the types specified
-		/// </summary>
-		/// <param name="typeSymbol"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		/// <remarks>This method should probably be rewritten so it doesn't merely compare the names, but instead the actual type.</remarks>
-		private static bool EqualsType(ITypeSymbol typeSymbol, params Type[] type)
-		{
-			// ContaningNamespace can be null, see https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/Symbols/ISymbol.cs#L76
-			var fullSymbolNameWithoutGeneric = typeSymbol.ContainingNamespace == null ? typeSymbol.Name : $"{typeSymbol.ContainingNamespace.ToDisplayString()}.{typeSymbol.Name}";
-			return type.Any(x => fullSymbolNameWithoutGeneric.Equals(x.FullName));
-		}
-	}
+                            syntaxNodeAnalysisContext.ReportDiagnostic(diagnostic);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if the <paramref name="typeSymbol"/> is one of the types specified
+        /// </summary>
+        /// <param name="typeSymbol"></param>
+        /// <param name="semanticModel">Semantic Model of the current context</param>
+        /// <param name="types">List of parameters that should match the symbol's type</param>
+        /// <returns></returns>
+        private static bool EqualsType(ITypeSymbol typeSymbol, SemanticModel semanticModel, params Type[] types)
+        {
+            var namedTypeSymbols = types.Select(x => semanticModel.Compilation.GetTypeByMetadataName(x.FullName));
+
+            var namedSymbol = typeSymbol as INamedTypeSymbol;
+            if (namedSymbol == null)
+                return false;
+
+            if (namedSymbol.IsGenericType)
+                return namedTypeSymbols.Any(t => namedSymbol.ConstructedFrom.Equals(t));
+            else
+                return namedTypeSymbols.Any(t => typeSymbol.Equals(t));
+        }
+    }
 }

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -56,7 +56,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning
                 {
                     if (node.Parent is ExpressionStatementSyntax)
                     {
-                        // Only checks for the two most common awaitable types. In principle this should instead check all types that are awaitable
+                        // Check the method return type against all the known awaitable types.
                         if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes))
                         {
                             var diagnostic = Diagnostic.Create(Rule, node.GetLocation(), methodSymbol.ToDisplayString());


### PR DESCRIPTION
Hi, I saw that this module wasn't `ValueTask` aware. I modified your matching rules to detect `ValueTask`, as well as a rewritten implementation of `EqualsType` that doesn't leverage on string comparison.