### PR TITLE
Implement an optional, stricter rule to handle cases where Task is assigned to a variable

### DIFF
--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/LindhartAnalyserMissingAwaitWarningUnitTests.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/LindhartAnalyserMissingAwaitWarningUnitTests.cs
@@ -35,6 +35,18 @@ namespace Lindhart.Analyser.MissingAwaitWarning.Test
                             new DiagnosticResultLocation("Test0.cs", 21, 13)
                         }
                 },
+                // Strict rule
+                new DiagnosticResult
+                {
+                    Id = "LindhartAnalyserMissingAwaitWarningStrict",
+                    Message = "The method 'AsyncAwaitGames.ICallee.DoSomethingAsync()' returns a Task that was not awaited",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = 
+                        new []
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 23, 24), 
+                        }
+                },
                 new DiagnosticResult
                 {
                     Id = "LindhartAnalyserMissingAwaitWarning",
@@ -46,6 +58,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning.Test
                             new DiagnosticResultLocation("Test0.cs", 26, 13)
                         }
                 },
+
             };
             
             VerifyCSharpDiagnostic(TestData.TestDiagnosis, expected);
@@ -65,6 +78,18 @@ namespace Lindhart.Analyser.MissingAwaitWarning.Test
                         new[]
                         {
                             new DiagnosticResultLocation("Test0.cs", 21, 13)
+                        }
+                },
+                // Strict rule
+                new DiagnosticResult
+                {
+                    Id = "LindhartAnalyserMissingAwaitWarningStrict",
+                    Message = "The method 'AsyncAwaitGames.ICallee.DoSomethingAsync()' returns a Task that was not awaited",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = 
+                        new []
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 23, 24), 
                         }
                 },
                 new DiagnosticResult

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
@@ -27,7 +27,7 @@ namespace AsyncAwaitGames
             // either.
             xxx.DoSomethingAsync(); // Should give a warning.
 
-            var task = xxx.DoSomethingAsync(); // Should not give a warning
+            var task = xxx.DoSomethingAsync(); // Should give a warning when strict rule enabled
             xxx.DoSomethingAsync().Result; // Should not give a warning
 
             xxx.DoSomethingAsync().ConfigureAwait(false); // Should give a warning
@@ -60,7 +60,7 @@ namespace AsyncAwaitGames
             // either.
             xxx.DoSomethingAsync(); // Should give a warning.
 
-            var task = xxx.DoSomethingAsync(); // Should not give a warning
+            var task = xxx.DoSomethingAsync(); // Should give a warning when strict rule enabled
             xxx.DoSomethingAsync().Result; // Should not give a warning
 
             xxx.DoSomethingAsync().ConfigureAwait(false); // Should give a warning
@@ -128,11 +128,10 @@ namespace AsyncAwaitGames
             await xxx.DoSomethingAsync(); // Should be fixed
             #endregion
 
-            var task = xxx.DoSomethingAsync(); 
+            var task = await xxx.DoSomethingAsync(); 
             xxx.DoSomethingAsync().Result; 
         }
     }
 }";
-
 	}
 }

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
@@ -101,8 +101,8 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
@@ -68,6 +68,7 @@
     <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -95,6 +96,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/packages.config
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+</packages>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/packages.config
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
@@ -30,8 +30,8 @@
    
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" PrivateAssets="all" />
-    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -8,7 +8,7 @@
   
   <PropertyGroup>
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
-    <PackageVersion>1.0.1.0</PackageVersion>
+    <PackageVersion>1.2.0.0</PackageVersion>
     <Authors>Morten Hartlev Lindhart, Alessandro Losi</Authors>
     <PackageLicenseUrl>https://github.com/ykoksen/unused-task-warning/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
@@ -25,7 +25,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>
     <RepositoryType>git (GitHub)</RepositoryType>
-    <Version>1.1.0.0</Version>
+    <Version>1.2.0</Version>    
   </PropertyGroup>
    
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -8,7 +8,7 @@
   
   <PropertyGroup>
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
-    <PackageVersion>1.0.1.0</PackageVersion>
+    <PackageVersion>1.1.0.0</PackageVersion>
     <Authors>Morten Hartlev Lindhart</Authors>
     <PackageLicenseUrl>https://github.com/ykoksen/unused-task-warning/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
@@ -25,12 +25,14 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>
     <RepositoryType>git (GitHub)</RepositoryType>
-    <Version>1.0.1.0</Version>
+    <Version>1.1.0.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
    
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" PrivateAssets="all" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -59,8 +59,8 @@ namespace Lindhart.Analyser.MissingAwaitWarning
                 {
                     switch (node.Parent)
                     {
+                        // Checks if a task is not awaited when the task itself is not assigned to a variable.
                         case ExpressionStatementSyntax _:
-                        {
                             // Check the method return type against all the known awaitable types.
                             if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes))
                             {
@@ -70,8 +70,10 @@ namespace Lindhart.Analyser.MissingAwaitWarning
                             }
 
                             break;
-                        }
+
+                        // Checks if a task is not awaited when the task itself is assigned to a variable.
                         case EqualsValueClauseSyntax _:
+
                             if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes))
                             {
                                 var diagnostic = Diagnostic.Create(StrictRule, node.GetLocation(), methodSymbol.ToDisplayString());

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning
         private const string Category = "UnintentionalUsage";
 
         private static readonly DiagnosticDescriptor StandardRule = new DiagnosticDescriptor(StandardRuleId, StandardTitle, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description);
-        private static readonly DiagnosticDescriptor StrictRule = new DiagnosticDescriptor(StrictRuleId, StrictTitle, MessageFormat, Category, DiagnosticSeverity.Warning, false, Description);
+        private static readonly DiagnosticDescriptor StrictRule = new DiagnosticDescriptor(StrictRuleId, StrictTitle, MessageFormat, Category, DiagnosticSeverity.Hidden, false, Description);
 
         private static readonly Type[] AwaitableTypes = new[]
         {
@@ -33,9 +33,9 @@ namespace Lindhart.Analyser.MissingAwaitWarning
             typeof(Task<>),
             typeof(ConfiguredTaskAwaitable),
             typeof(ConfiguredTaskAwaitable<>),
-            //typeof(ValueTask), // can't make this to work
+            //typeof(ValueTask), // Type not available yet in .net standard
             typeof(ValueTask<>),
-            //typeof(ConfiguredValueTaskAwaitable), // can't make this to work
+            //typeof(ConfiguredValueTaskAwaitable), // Type not available yet in .net standard
             typeof(ConfiguredValueTaskAwaitable<>)
         };
 

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -43,10 +43,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning
 
         public override void Initialize(AnalysisContext context)
         {
-            var x = EqualsType(null, null);
-
             context.RegisterSyntaxNodeAction(AnalyseSymbolNode, SyntaxKind.InvocationExpression);
-            //context.RegisterSyntaxNodeAction(AnalyseTaskAssignNode, SyntaxKind.LocalDeclarationStatement);
         }
 
         private void AnalyseSymbolNode(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
@@ -87,42 +84,6 @@ namespace Lindhart.Analyser.MissingAwaitWarning
                 }
             }
         }
-
-/*        private void AnalyseTaskAssignNode(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is LocalDeclarationStatementSyntax localDeclaration)
-            {
-                var declaratorSyntax = localDeclaration.Declaration
-                    .ChildNodes()
-                    .OfType<VariableDeclaratorSyntax>()
-                    .FirstOrDefault();
-
-                if (declaratorSyntax == null)
-                    return;
-
-                if (declaratorSyntax.Initializer.Value is InvocationExpressionSyntax node)
-                {
-                    var symbolInfo = context
-                        .SemanticModel
-                        .GetSymbolInfo(node.Expression, context.CancellationToken);
-
-                    if ((symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault())
-                        is IMethodSymbol methodSymbol)
-                    {
-                        if (node.Parent is EqualsValueClauseSyntax)
-                        {
-                            // Check the method return type against all the known awaitable types.
-                            if (EqualsType(methodSymbol.ReturnType, context.SemanticModel, AwaitableTypes))
-                            {
-                                var diagnostic = Diagnostic.Create(StrictRule, node.GetLocation(), methodSymbol.ToDisplayString());
-
-                                context.ReportDiagnostic(diagnostic);
-                            }
-                        }
-                    }
-                }
-            }
-        }*/
 
         /// <summary>
         /// Checks if the <paramref name="typeSymbol"/> is one of the types specified

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningCodeFixProvider.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningCodeFixProvider.cs
@@ -18,45 +18,48 @@ namespace Lindhart.Analyser.MissingAwaitWarning
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LindhartAnalyserMissingAwaitWarningCodeFixProvider)), Shared]
     public class LindhartAnalyserMissingAwaitWarningCodeFixProvider : CodeFixProvider
     {
-		private const string Title = "Insert 'await' keyword";
+        private const string Title = "Insert 'await' keyword";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(LindhartAnalyserMissingAwaitWarningAnalyzer.StandardRuleId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+            LindhartAnalyserMissingAwaitWarningAnalyzer.StandardRuleId,
+            LindhartAnalyserMissingAwaitWarningAnalyzer.StrictRuleId // This use case is already covered by a standard roslyn code fix. Should we still add our for coherence?
+            );
 
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-			var diagnostic = context.Diagnostics.First();
-			var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-			// Find the type declaration identified by the diagnostic.
-			var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
+            // Find the type declaration identified by the diagnostic.
+            var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
 
-			// Register a code action that will invoke the fix.
-			context.RegisterCodeFix(
-					CodeAction.Create(
-							title: Title,
-							createChangedDocument: c => InsertAwaitKeyword(context.Document, declaration, c),
-							equivalenceKey: Title),
-					diagnostic);
-		}
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                    CodeAction.Create(
+                            title: Title,
+                            createChangedDocument: c => InsertAwaitKeyword(context.Document, declaration, c),
+                            equivalenceKey: Title),
+                    diagnostic);
+        }
 
-		private async Task<Document> InsertAwaitKeyword(Document document, InvocationExpressionSyntax declaration, CancellationToken cancellationToken)
-		{
-			// Get comments (comments and stuff)
-			var firstToken = declaration.GetFirstToken();
-			var leadingTrivia = firstToken.LeadingTrivia;
-			// Remove comments
-			var newDeclaration = declaration.ReplaceToken(firstToken, firstToken.WithLeadingTrivia(SyntaxTriviaList.Empty));
+        private async Task<Document> InsertAwaitKeyword(Document document, InvocationExpressionSyntax declaration, CancellationToken cancellationToken)
+        {
+            // Get comments (comments and stuff)
+            var firstToken = declaration.GetFirstToken();
+            var leadingTrivia = firstToken.LeadingTrivia;
+            // Remove comments
+            var newDeclaration = declaration.ReplaceToken(firstToken, firstToken.WithLeadingTrivia(SyntaxTriviaList.Empty));
 
-			// Create 'await' expression before the problem
-			AwaitExpressionSyntax awaiter = SyntaxFactory.AwaitExpression(newDeclaration);
+            // Create 'await' expression before the problem
+            AwaitExpressionSyntax awaiter = SyntaxFactory.AwaitExpression(newDeclaration);
 
-			// Replace the node with the new node - and insert trivia on the new node
-			var rootNode = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = rootNode.ReplaceNode(declaration, awaiter.WithLeadingTrivia(leadingTrivia));
+            // Replace the node with the new node - and insert trivia on the new node
+            var rootNode = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = rootNode.ReplaceNode(declaration, awaiter.WithLeadingTrivia(leadingTrivia));
 
-			return document.WithSyntaxRoot(newRoot);
-		}
-	}
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
 }

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningCodeFixProvider.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningCodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning
     {
 		private const string Title = "Insert 'await' keyword";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(LindhartAnalyserMissingAwaitWarningAnalyzer.DiagnosticId);
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(LindhartAnalyserMissingAwaitWarningAnalyzer.StandardRuleId);
 
 		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 		{

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.Designer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.Designer.cs
@@ -82,9 +82,18 @@ namespace Lindhart.Analyser.MissingAwaitWarning {
         /// <summary>
         ///   Looks up a localized string similar to Possible missing await keyword.
         /// </summary>
-        internal static string AnalyzerTitle {
+        internal static string StandardRuleTitle {
             get {
-                return ResourceManager.GetString("AnalyzerTitle", resourceCulture);
+                return ResourceManager.GetString("StandardRuleTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Possible unwanted Task returned from method.
+        /// </summary>
+        internal static string StrictRuleTitle {
+            get {
+                return ResourceManager.GetString("StrictRuleTitle", resourceCulture);
             }
         }
     }

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.resx
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.resx
@@ -125,8 +125,12 @@
     <value>The method '{0}' returns a Task that was not awaited</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
-  <data name="AnalyzerTitle" xml:space="preserve">
+  <data name="StandardRuleTitle" xml:space="preserve">
     <value>Possible missing await keyword</value>
     <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="StrictRuleTitle" xml:space="preserve">
+    <value>Possible unwanted Task returned from method</value>
+    <comment>The title of the more strict diagnostic.</comment>
   </data>
 </root>


### PR DESCRIPTION
Take the following line of code:

    var myResult = TotallySyncMethod();

Suppose that during a refactor, `TotallySyncMethod` becomes `async`. The old invokation is still valid, and could only lead to errors near when `myResult` is used in a certain way.

I've implemented a rule, disabled by default, that signal this case. I opted not to enable that by default because there are many cases when I would explicitly return a `Task` and use it as such.