### PR TITLE
A couple of improvements for the stricter rule

### DIFF
--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/LindhartAnalyserMissingAwaitWarningAnalyzer.cs
@@ -21,11 +21,12 @@ namespace Lindhart.Analyser.MissingAwaitWarning
         private static readonly LocalizableString StandardTitle = new LocalizableResourceString(nameof(Resources.StandardRuleTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString StrictTitle = new LocalizableResourceString(nameof(Resources.StandardRuleTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormatStrict = new LocalizableResourceString(nameof(Resources.StrictAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
         private const string Category = "UnintentionalUsage";
 
         private static readonly DiagnosticDescriptor StandardRule = new DiagnosticDescriptor(StandardRuleId, StandardTitle, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description);
-        private static readonly DiagnosticDescriptor StrictRule = new DiagnosticDescriptor(StrictRuleId, StrictTitle, MessageFormat, Category, DiagnosticSeverity.Hidden, false, Description);
+        private static readonly DiagnosticDescriptor StrictRule = new DiagnosticDescriptor(StrictRuleId, StrictTitle, MessageFormatStrict, Category, DiagnosticSeverity.Hidden, false, Description);
 
         private static readonly Type[] AwaitableTypes = new[]
         {
@@ -74,7 +75,7 @@ namespace Lindhart.Analyser.MissingAwaitWarning
                         // Checks if a task is not awaited when the task itself is assigned to a variable.
                         case EqualsValueClauseSyntax _:
 
-                            if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes))
+                            if (EqualsType(methodSymbol.ReturnType, syntaxNodeAnalysisContext.SemanticModel, AwaitableTypes) && methodSymbol.IsAsync)
                             {
                                 var diagnostic = Diagnostic.Create(StrictRule, node.GetLocation(), methodSymbol.ToDisplayString());
 

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.Designer.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.Designer.cs
@@ -89,6 +89,15 @@ namespace Lindhart.Analyser.MissingAwaitWarning {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The async method &apos;{0}&apos; returns a Task that is not awaited. This could be the expected behaviour, depending of your context..
+        /// </summary>
+        internal static string StrictAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("StrictAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Possible unwanted Task returned from method.
         /// </summary>
         internal static string StrictRuleTitle {

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.resx
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Resources.resx
@@ -129,6 +129,10 @@
     <value>Possible missing await keyword</value>
     <comment>The title of the diagnostic.</comment>
   </data>
+  <data name="StrictAnalyzerMessageFormat" xml:space="preserve">
+    <value>The async method '{0}' returns a Task that is not awaited. This could be the expected behaviour, depending of your context.</value>
+    <comment>The format-able message the diagnostic displays for the stricter async rule.</comment>
+  </data>
   <data name="StrictRuleTitle" xml:space="preserve">
     <value>Possible unwanted Task returned from method</value>
     <comment>The title of the more strict diagnostic.</comment>


### PR DESCRIPTION
I've modified a couple of things:
- Since my stricter check would only be relevant in cases where the callee is an async method, I've added that condition, intended to limit the "noise" of that check.
- I've added a more clear warning message for the new check, which specifies that the behaviour could be the expected one.

Let me know what you think!