### PR TITLE
Add warning when returning a task without await

### DIFF
--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/LindhartAnalyserMissingAwaitWarningUnitTests.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/LindhartAnalyserMissingAwaitWarningUnitTests.cs
@@ -109,6 +109,27 @@ namespace Lindhart.Analyser.MissingAwaitWarning.Test
         }
 
         [TestMethod]
+        public void VerifyCode_ProblematicCode_ExpectWarningForProblem_ReturnTask()
+        {
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = "LindhartAnalyserMissingAwaitWarningStrict",
+                    Message = "The method 'AsyncAwaitGames.ICallee.DoSomethingAsync()' returns a Task that was not awaited",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                        new[]
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 18, 20)
+                        }
+                }
+            };
+
+            VerifyCSharpDiagnostic(TestData.TestDiagnosisReturnTask, expected);
+        }
+
+        [TestMethod]
         public void VerifyCodeFix_CodeFixApplied_CodeIsFixed()
         {
             VerifyCSharpFix(TestData.FixTestInput, TestData.FixTestOutput, allowNewCompilerDiagnostics: true);

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/TestData.cs
@@ -68,6 +68,31 @@ namespace AsyncAwaitGames
     }
 }";
 
+        /// <summary>
+        /// File for testing diagnosis
+        /// </summary>
+        public const string TestDiagnosisReturnTask = @"
+using System.Threading.Tasks;
+namespace AsyncAwaitGames
+{
+    // In my real case, that method just returns Task.
+    public interface ICallee { Task<int> DoSomethingAsync(); }
+
+    public class Callee : ICallee
+    {
+        public async Task<int> DoSomethingAsync() => await Task.FromResult(0); // Should not give a warning
+    }
+    public class Caller
+    {
+        public Task<int> DoCall()
+        {
+            ICallee xxx = new Callee();
+
+            return xxx.DoSomethingAsync(); // Should give a warning
+        }
+    }
+}";
+
 		/// <summary>
 		/// Input that should be fixed
 		/// </summary>


### PR DESCRIPTION
I've had an issue where I lost the full call stack from an exception, because I had the following flow:
```C#
async Task Method1()
{
    await Method2();
}

Task Method2()
{
    ...
    return Method3(); // Should give a warning, but it doesn't right now.
}

async Task Method3()
{
    ... await ...
    // An exception is thrown somewhere down the line here.
}
```

This PR adds the check to catch these issues.