### PR TITLE
Enable automatic build and minor corrections

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,8 +14,8 @@ jobs:
       with:
         dotnet-version: 3.1.301
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore **/*.sln
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore **/*.sln
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal **/*.sln

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,7 +20,11 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal **/*.sln
     - name: Create package
-      run: dotnet pack -v normal -c Release --no-restore -p:PackageVersion=$GITHUB_RUN_ID Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+      run: | 
+        arrTag=(${GITHUB_REF//\// })
+        VERSION="${arrTag[2]}"
+        VERSION="${VERSION//v}"
+        dotnet pack -v normal -c Release --no-restore -p:PackageVersion=$VERSION Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal **/*.sln
     - name: Create package
-      run: dotnet pack -v normal -c Release --no-restore --include-source -p:PackageVersion=$GITHUB_RUN_ID Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+      run: dotnet pack -v normal -c Release --no-restore -p:PackageVersion=$GITHUB_RUN_ID Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal **/*.sln
     - name: Create package
-      run: dotnet pack -v normal -c Release --no-restore Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+      run: dotnet pack -p:PackageVersion=2.0.0-beta -v normal -c Release --no-restore Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,3 +19,10 @@ jobs:
       run: dotnet build --configuration Release --no-restore **/*.sln
     - name: Test
       run: dotnet test --no-restore --verbosity normal **/*.sln
+    - name: Create package
+      run: dotnet pack -v normal -c Release --no-restore --include-source -p:PackageVersion=$GITHUB_RUN_ID Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+    - name: Upload package as Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: nupkg
+        path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/**/*.nupkg

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,4 +25,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: nupkg
-        path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/**/*.nupkg
+        path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/**/Release/*.nupkg

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,5 +24,4 @@ jobs:
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: nupkg
-        path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/**/Release/*.nupkg
+        path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/Release/*.nupkg

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,11 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal **/*.sln
     - name: Create package
-      run: | 
-        arrTag=(${GITHUB_REF//\// })
-        VERSION="${arrTag[2]}"
-        VERSION="${VERSION//v}"
-        dotnet pack -v normal -c Release --no-restore -p:PackageVersion=$VERSION Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+      run: dotnet pack -v normal -c Release --no-restore Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,4 +24,5 @@ jobs:
     - name: Upload package as Artifact
       uses: actions/upload-artifact@v2
       with:
+        name: NuGetPackage
         path: ./Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/bin/Release/*.nupkg

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,21 @@
+name: .NET Core
+
+on: [push, pull_request]  
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.sln
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lindhart.Analyser.MissingAwaitWarning", "Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning.csproj", "{693F69C1-D89E-4CB6-9C1A-F4926E5ADE74}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lindhart.Analyser.MissingAwaitWarning", "Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning.csproj", "{693F69C1-D89E-4CB6-9C1A-F4926E5ADE74}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lindhart.Analyser.MissingAwaitWarning.Test", "Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning.Test\Lindhart.Analyser.MissingAwaitWarning.Test.csproj", "{9F091191-604B-4212-AD9A-D08B8CFA107A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lindhart.Analyser.MissingAwaitWarning.Test", "Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning.Test\Lindhart.Analyser.MissingAwaitWarning.Test.csproj", "{9F091191-604B-4212-AD9A-D08B8CFA107A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lindhart.Analyser.MissingAwaitWarning.Vsix", "Lindhart.Analyser.MissingAwaitWarning\Lindhart.Analyser.MissingAwaitWarning.Vsix\Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj", "{479432C8-F135-4C2D-B250-CBA41CB8F40B}"
 EndProject
@@ -24,9 +24,7 @@ Global
 		{9F091191-604B-4212-AD9A-D08B8CFA107A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F091191-604B-4212-AD9A-D08B8CFA107A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{479432C8-F135-4C2D-B250-CBA41CB8F40B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{479432C8-F135-4C2D-B250-CBA41CB8F40B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{479432C8-F135-4C2D-B250-CBA41CB8F40B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{479432C8-F135-4C2D-B250-CBA41CB8F40B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Test/Lindhart.Analyser.MissingAwaitWarning.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.Vsix/Lindhart.Analyser.MissingAwaitWarning.Vsix.csproj
@@ -26,7 +26,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -8,14 +8,13 @@
   
   <PropertyGroup>
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
-    <PackageVersion>1.2.1</PackageVersion>
-    <Authors>Morten Hartlev Lindhart, Alessandro Losi</Authors>
+    <Authors>Morten Hartlev Lindhart, Alessandro Losi, Arthur Liberman</Authors>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/ykoksen/unused-task-warning.git</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>When using dependency injection and async-await pattern it is possible to end up with an interface with a method that returns a Task. If this interface method is used in a synchronous method there is a likelihood that it will erroneously be run as a fire and forget method. In this situation this analyser generates a warning.</Description>
-    <PackageReleaseNotes>Dependent packages are now private assets</PackageReleaseNotes>
+    <PackageReleaseNotes>Package is no longer signed. Upgraded target framework from .net Standard 1.3 -> 2.0. Changed from license file to license expression (still MIT license). Added more types.</PackageReleaseNotes>
     <Copyright></Copyright>
     <PackageTags>Lindhart.Analyser.MissingAwaitWarning, analyzers, async, await, Task</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -24,7 +23,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>
     <RepositoryType>git (GitHub)</RepositoryType>
-    <Version>1.2.1</Version>
+    <Version>2.0.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
    

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -10,7 +10,6 @@
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
     <PackageVersion>1.2.1</PackageVersion>
     <Authors>Morten Hartlev Lindhart, Alessandro Losi</Authors>
-    <PackageLicenseUrl>https://github.com/ykoksen/unused-task-warning/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/ykoksen/unused-task-warning.git</RepositoryUrl>
@@ -26,7 +25,7 @@
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>
     <RepositoryType>git (GitHub)</RepositoryType>
     <Version>1.2.1</Version>
-    <PackageLicenseExpression />
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
    

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -10,7 +10,7 @@
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
     <PackageVersion>1.2.1</PackageVersion>
     <Authors>Morten Hartlev Lindhart, Alessandro Losi</Authors>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/ykoksen/unused-task-warning/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/ykoksen/unused-task-warning.git</RepositoryUrl>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -26,7 +26,6 @@
     <RepositoryType>git (GitHub)</RepositoryType>
     <Version>1.2.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
    
   <ItemGroup>
@@ -43,10 +42,6 @@
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="..\Lindhart.Analyser.MissingAwaitWarning.Vsix\LICENSE.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -8,7 +8,7 @@
   
   <PropertyGroup>
     <PackageId>Lindhart.Analyser.MissingAwaitWarning</PackageId>
-    <Authors>Morten Hartlev Lindhart, Alessandro Losi, Arthur Liberman</Authors>
+    <Authors>Morten Hartlev Lindhart, Alessandro Losi, Joris Vergeer</Authors>
     <PackageProjectUrl>https://github.com/ykoksen/unused-task-warning</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/ykoksen/unused-task-warning.git</RepositoryUrl>

--- a/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
+++ b/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning/Lindhart.Analyser.MissingAwaitWarning.csproj
@@ -22,7 +22,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <Company />
     <Product>Missing await warning</Product>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>LindhartKey.pfx</AssemblyOriginatorKeyFile>
     <RepositoryType>git (GitHub)</RepositoryType>
     <Version>1.2.1</Version>


### PR DESCRIPTION
Enabled automatic build in GitHub.
Upgraded to .Net Standard 2.0 since .Net Standard is going out of support (and it seems it can still be used for older projects anyway).
Updated license method.
